### PR TITLE
Fix 2.4.0 Installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
   - composer require ampersand/travis-vanilla-magento dev-$TRAVIS_BRANCH || composer require ampersand/travis-vanilla-magento $TRAVIS_BRANCH
 
 script:
+  - if [[ $TEST_GROUP = two_three ]]; then  phpenv versions; phpenv global 7.2; fi
   - if [[ $TEST_GROUP = two_three ]]; then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1 VERSION=2.3.3  . ./vendor/bin/travis-install-magento.sh; fi
   - if [[ $TEST_GROUP = latest ]];    then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1                . ./vendor/bin/travis-install-magento.sh; fi
   - echo "Travis Run Done"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,13 @@ script:
   - if [[ $TEST_GROUP = two_three ]]; then  phpenv versions; phpenv global 7.2; fi
   - if [[ $TEST_GROUP = two_three ]]; then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1 VERSION=2.3.3  . ./vendor/bin/travis-install-magento.sh; fi
   - if [[ $TEST_GROUP = latest ]]; then  
-        sudo apt-get remove elasticsearch -y && \
-        curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb && \
-        sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb && \
-        sudo chown elasticsearch:elasticsearch /etc/default/elasticsearch && \
-        sudo service elasticsearch restart && \
-        sleep 5 && \
-        curl -XGET 'localhost:9200'; 
+        sudo apt-get remove elasticsearch -y &&\
+        curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb &&\
+        sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb &&\
+        sudo chown elasticsearch:elasticsearch /etc/default/elasticsearch &&\
+        sudo service elasticsearch restart &&\
+        sleep 5 &&\
+        curl -XGET 'localhost:9200';
     fi
   - if [[ $TEST_GROUP = latest ]];    then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1                . ./vendor/bin/travis-install-magento.sh; fi
   - echo "Travis Run Done"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,12 @@ script:
   - if [[ $TEST_GROUP = two_three ]]; then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1 VERSION=2.3.3  . ./vendor/bin/travis-install-magento.sh; fi
   - if [[ $TEST_GROUP = latest ]]; then  
         sudo apt-get remove elasticsearch -y &&\
-        curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb &&\
-        sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb &&\
-        sudo chown elasticsearch:elasticsearch /etc/default/elasticsearch &&\
-        sudo service elasticsearch restart &&\
-        sleep 5 &&\
-        curl -XGET 'localhost:9200';
+curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb &&\
+sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb &&\
+sudo chown elasticsearch:elasticsearch /etc/default/elasticsearch &&\
+sudo service elasticsearch restart &&\
+sleep 5 &&\
+curl -XGET 'localhost:9200';
     fi
   - if [[ $TEST_GROUP = latest ]];    then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1                . ./vendor/bin/travis-install-magento.sh; fi
   - echo "Travis Run Done"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,10 @@ install:
   - composer require ampersand/travis-vanilla-magento dev-$TRAVIS_BRANCH || composer require ampersand/travis-vanilla-magento $TRAVIS_BRANCH
 
 script:
-  - curl -XGET 'localhost:9200' || true # what version of elasticsearch are we using?
   - if [[ $TEST_GROUP = two_three ]]; then  phpenv versions; phpenv global 7.2; fi
   - if [[ $TEST_GROUP = two_three ]]; then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1 VERSION=2.3.3  . ./vendor/bin/travis-install-magento.sh; fi
+  - if [[ $TEST_GROUP = latest ]];    then  curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb && sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb && sudo service elasticsearch restart && sleep 10; fi
+  - if [[ $TEST_GROUP = latest ]];    then  curl -XGET 'localhost:9200'; fi
   - if [[ $TEST_GROUP = latest ]];    then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1                . ./vendor/bin/travis-install-magento.sh; fi
   - echo "Travis Run Done"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,23 +15,23 @@ env:
   - TEST_GROUP=two_three
 
 install:
-  - cd test
-  - composer install --no-interaction
-  - composer require ampersand/travis-vanilla-magento dev-$TRAVIS_BRANCH || composer require ampersand/travis-vanilla-magento $TRAVIS_BRANCH
+  - #cd test
+  - #composer install --no-interaction
+  - #composer require ampersand/travis-vanilla-magento dev-$TRAVIS_BRANCH || composer require ampersand/travis-vanilla-magento $TRAVIS_BRANCH
 
 script:
-  - if [[ $TEST_GROUP = two_three ]]; then  phpenv versions; phpenv global 7.2; fi
-  - if [[ $TEST_GROUP = two_three ]]; then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1 VERSION=2.3.3  . ./vendor/bin/travis-install-magento.sh; fi
+  - #if [[ $TEST_GROUP = two_three ]]; then  phpenv versions; phpenv global 7.2; fi
+  - #if [[ $TEST_GROUP = two_three ]]; then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1 VERSION=2.3.3  . ./vendor/bin/travis-install-magento.sh; fi
   - if [[ $TEST_GROUP = latest ]]; then  
-        sudo apt-get remove elasticsearch -y &&\
-curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb &&\
-sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb &&\
-sudo chown elasticsearch:elasticsearch /etc/default/elasticsearch &&\
-sudo service elasticsearch restart &&\
-sleep 5 &&\
-curl -XGET 'localhost:9200';
+        sudo apt-get remove elasticsearch -y && \
+        curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb && \
+        sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb && \
+        sudo chown elasticsearch:elasticsearch /etc/default/elasticsearch && \
+        sudo service elasticsearch restart && \
+        sleep 5 && \
+        curl -XGET 'localhost:9200';
     fi
-  - if [[ $TEST_GROUP = latest ]];    then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1                . ./vendor/bin/travis-install-magento.sh; fi
+  - #if [[ $TEST_GROUP = latest ]];    then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1                . ./vendor/bin/travis-install-magento.sh; fi
   - echo "Travis Run Done"
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,7 @@ install:
 script:
   - #if [[ $TEST_GROUP = two_three ]]; then  phpenv versions; phpenv global 7.2; fi
   - #if [[ $TEST_GROUP = two_three ]]; then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1 VERSION=2.3.3  . ./vendor/bin/travis-install-magento.sh; fi
-  - if [[ $TEST_GROUP = latest ]]; then  
-        sudo apt-get remove elasticsearch -y && \
-        curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb && \
-        sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb && \
-        sudo chown elasticsearch:elasticsearch /etc/default/elasticsearch && \
-        sudo service elasticsearch restart && \
-        sleep 5 && \
-        curl -XGET 'localhost:9200';
-    fi
+  - if [[ $TEST_GROUP = latest ]]; then  sudo apt-get remove elasticsearch -y && curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb && sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb && sudo chown elasticsearch:elasticsearch /etc/default/elasticsearch && sudo service elasticsearch restart && sleep 5 && curl -XGET 'localhost:9200'; fi
   - #if [[ $TEST_GROUP = latest ]];    then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1                . ./vendor/bin/travis-install-magento.sh; fi
   - echo "Travis Run Done"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,15 @@ install:
 script:
   - if [[ $TEST_GROUP = two_three ]]; then  phpenv versions; phpenv global 7.2; fi
   - if [[ $TEST_GROUP = two_three ]]; then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1 VERSION=2.3.3  . ./vendor/bin/travis-install-magento.sh; fi
-  - if [[ $TEST_GROUP = latest ]];    then  curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb && sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb && sudo service elasticsearch restart && sleep 10; fi
-  - if [[ $TEST_GROUP = latest ]];    then  curl -XGET 'localhost:9200'; fi
+  - if [[ $TEST_GROUP = latest ]]; then  
+        sudo apt-get remove elasticsearch -y && \
+        curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb && \
+        sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb && \
+        sudo chown elasticsearch:elasticsearch /etc/default/elasticsearch && \
+        sudo service elasticsearch restart && \
+        sleep 5 && \
+        curl -XGET 'localhost:9200'; 
+    fi
   - if [[ $TEST_GROUP = latest ]];    then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1                . ./vendor/bin/travis-install-magento.sh; fi
   - echo "Travis Run Done"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,15 @@ env:
   - TEST_GROUP=two_three
 
 install:
-  - #cd test
-  - #composer install --no-interaction
-  - #composer require ampersand/travis-vanilla-magento dev-$TRAVIS_BRANCH || composer require ampersand/travis-vanilla-magento $TRAVIS_BRANCH
+  - cd test
+  - composer install --no-interaction
+  - composer require ampersand/travis-vanilla-magento dev-$TRAVIS_BRANCH || composer require ampersand/travis-vanilla-magento $TRAVIS_BRANCH
 
 script:
-  - #if [[ $TEST_GROUP = two_three ]]; then  phpenv versions; phpenv global 7.2; fi
-  - #if [[ $TEST_GROUP = two_three ]]; then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1 VERSION=2.3.3  . ./vendor/bin/travis-install-magento.sh; fi
+  - if [[ $TEST_GROUP = two_three ]]; then  phpenv versions; phpenv global 7.2; fi
+  - if [[ $TEST_GROUP = two_three ]]; then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1 VERSION=2.3.3  . ./vendor/bin/travis-install-magento.sh; fi
   - if [[ $TEST_GROUP = latest ]]; then  sudo apt-get remove elasticsearch -y && curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb && sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb && sudo chown elasticsearch:elasticsearch /etc/default/elasticsearch && sudo service elasticsearch restart && sleep 5 && curl -XGET 'localhost:9200'; fi
-  - #if [[ $TEST_GROUP = latest ]];    then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1                . ./vendor/bin/travis-install-magento.sh; fi
+  - if [[ $TEST_GROUP = latest ]];    then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1                . ./vendor/bin/travis-install-magento.sh; fi
   - echo "Travis Run Done"
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ addons:
 
 services:
   - mysql
-  - elasticsearch
 
 cache:
   apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
   - composer require ampersand/travis-vanilla-magento dev-$TRAVIS_BRANCH || composer require ampersand/travis-vanilla-magento $TRAVIS_BRANCH
 
 script:
+  - curl -XGET 'localhost:9200' || true # what version of elasticsearch are we using?
   - if [[ $TEST_GROUP = two_three ]]; then  phpenv versions; phpenv global 7.2; fi
   - if [[ $TEST_GROUP = two_three ]]; then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1 VERSION=2.3.3  . ./vendor/bin/travis-install-magento.sh; fi
   - if [[ $TEST_GROUP = latest ]];    then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1                . ./vendor/bin/travis-install-magento.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
-php: 7.3
+php: 7.4
+dist: xenial
 
 notifications:
   email:
@@ -32,6 +33,7 @@ addons:
 
 services:
   - mysql
+  - elasticsearch
 
 cache:
   apt: true

--- a/travis-install-magento.sh
+++ b/travis-install-magento.sh
@@ -83,7 +83,7 @@ function install_magento() {
 
     printf "\033[92m###### Running installation ######\n\n\033[0m";
 
-    travis_wait 30 php bin/magento setup:install \
+    php bin/magento setup:install \
         --admin-firstname=ampersand --admin-lastname=developer --admin-email=example@example.com \
         --admin-user=admin --admin-password=somepassword123 \
         --db-name=$DATABASE_NAME --db-user=root --db-host=127.0.0.1\

--- a/travis-install-magento.sh
+++ b/travis-install-magento.sh
@@ -83,7 +83,7 @@ function install_magento() {
 
     printf "\033[92m###### Running installation ######\n\n\033[0m";
 
-    php bin/magento setup:install \
+    travis_wait 30 php bin/magento setup:install \
         --admin-firstname=ampersand --admin-lastname=developer --admin-email=example@example.com \
         --admin-user=admin --admin-password=somepassword123 \
         --db-name=$DATABASE_NAME --db-user=root --db-host=127.0.0.1\


### PR DESCRIPTION
https://travis-ci.org/github/AmpersandHQ/travis-vanilla-magento/jobs/713223341

```
Installing search configuration...
In SearchConfig.php line 81:
                                                                               
  Could not validate a connection to Elasticsearch. No alive nodes found in y  
  our cluster                                                                  
                                                                              
```

Install the correct version of ES for magento 2.4