### PR TITLE
Add FULL_INSTALL flag so this can be used for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,7 @@ install:
 script:
   - if [[ $TEST_GROUP = two_three ]];             then  phpenv versions; phpenv global 7.2; fi
   - if [[ $TEST_GROUP = two_three ]];             then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1 VERSION=2.3.3  . ./vendor/bin/travis-install-magento.sh; fi
-  - if [[ $TEST_GROUP = latest ]];                then  sudo apt-get remove elasticsearch -y && curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb && sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb && sudo chown elasticsearch:elasticsearch /etc/default/elasticsearch && sudo service elasticsearch restart && sleep 5 && curl -XGET 'localhost:9200'; fi
   - if [[ $TEST_GROUP = latest ]];                then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1                . ./vendor/bin/travis-install-magento.sh; fi
-  - if [[ $TEST_GROUP = latest-integration ]];    then  sudo apt-get remove elasticsearch -y && curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb && sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb && sudo chown elasticsearch:elasticsearch /etc/default/elasticsearch && sudo service elasticsearch restart && sleep 5 && curl -XGET 'localhost:9200'; fi
   - if [[ $TEST_GROUP = latest-integration ]];    then  NAME=$TEST_GROUP FULL_INSTALL=0                    . ./vendor/bin/travis-install-magento.sh; fi
   - echo "Travis Run Done"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ notifications:
     on_error: always
 
 env:
+  - TEST_GROUP=latest-integration
   - TEST_GROUP=latest
   - TEST_GROUP=two_three
 
@@ -22,10 +23,12 @@ install:
   - composer require ampersand/travis-vanilla-magento:"dev-$TRAVIS_BRANCH" || composer require ampersand/travis-vanilla-magento $TRAVIS_BRANCH
 
 script:
-  - if [[ $TEST_GROUP = two_three ]]; then  phpenv versions; phpenv global 7.2; fi
-  - if [[ $TEST_GROUP = two_three ]]; then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1 VERSION=2.3.3  . ./vendor/bin/travis-install-magento.sh; fi
-  - if [[ $TEST_GROUP = latest ]]; then  sudo apt-get remove elasticsearch -y && curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb && sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb && sudo chown elasticsearch:elasticsearch /etc/default/elasticsearch && sudo service elasticsearch restart && sleep 5 && curl -XGET 'localhost:9200'; fi
-  - if [[ $TEST_GROUP = latest ]];    then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1                . ./vendor/bin/travis-install-magento.sh; fi
+  - if [[ $TEST_GROUP = two_three ]];             then  phpenv versions; phpenv global 7.2; fi
+  - if [[ $TEST_GROUP = two_three ]];             then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1 VERSION=2.3.3  . ./vendor/bin/travis-install-magento.sh; fi
+  - if [[ $TEST_GROUP = latest ]];                then  sudo apt-get remove elasticsearch -y && curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb && sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb && sudo chown elasticsearch:elasticsearch /etc/default/elasticsearch && sudo service elasticsearch restart && sleep 5 && curl -XGET 'localhost:9200'; fi
+  - if [[ $TEST_GROUP = latest ]];                then  NAME=$TEST_GROUP WITH_SAMPLE_DATA=1                . ./vendor/bin/travis-install-magento.sh; fi
+  - if [[ $TEST_GROUP = latest-integration ]];    then  sudo apt-get remove elasticsearch -y && curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb && sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb && sudo chown elasticsearch:elasticsearch /etc/default/elasticsearch && sudo service elasticsearch restart && sleep 5 && curl -XGET 'localhost:9200'; fi
+  - if [[ $TEST_GROUP = latest-integration ]];    then  NAME=$TEST_GROUP FULL_INSTALL=0                    . ./vendor/bin/travis-install-magento.sh; fi
   - echo "Travis Run Done"
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ addons:
     - postfix
     - apache2
     - libapache2-mod-fastcgi
+    - rabbitmq
 
 services:
   - mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ addons:
     - postfix
     - apache2
     - libapache2-mod-fastcgi
-    - rabbitmq
 
 services:
   - mysql

--- a/install-config-mysql.travis-no-rabbitmq.php.dist
+++ b/install-config-mysql.travis-no-rabbitmq.php.dist
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+return [
+    'db-host' => '127.0.0.1',
+    'db-user' => 'root',
+    'db-password' => '',
+    'db-name' => 'magento_integration_tests',
+    'db-prefix' => 'trv_',
+    'backend-frontname' => 'backend',
+    'admin-user' => \Magento\TestFramework\Bootstrap::ADMIN_NAME,
+    'admin-password' => \Magento\TestFramework\Bootstrap::ADMIN_PASSWORD,
+    'admin-email' => \Magento\TestFramework\Bootstrap::ADMIN_EMAIL,
+    'admin-firstname' => \Magento\TestFramework\Bootstrap::ADMIN_FIRSTNAME,
+    'admin-lastname' => \Magento\TestFramework\Bootstrap::ADMIN_LASTNAME,
+];

--- a/install-config-mysql.travis.php.dist
+++ b/install-config-mysql.travis.php.dist
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+return [
+    'db-host' => '127.0.0.1',
+    'db-user' => 'root',
+    'db-password' => '',
+    'db-name' => 'magento_integration_tests',
+    'db-prefix' => 'trv_',
+    'backend-frontname' => 'backend',
+    'admin-user' => \Magento\TestFramework\Bootstrap::ADMIN_NAME,
+    'admin-password' => \Magento\TestFramework\Bootstrap::ADMIN_PASSWORD,
+    'admin-email' => \Magento\TestFramework\Bootstrap::ADMIN_EMAIL,
+    'admin-firstname' => \Magento\TestFramework\Bootstrap::ADMIN_FIRSTNAME,
+    'admin-lastname' => \Magento\TestFramework\Bootstrap::ADMIN_LASTNAME,
+    'amqp-host' => 'localhost',
+    'amqp-port' => '5672',
+    'amqp-user' => 'guest',
+    'amqp-password' => 'guest',
+];

--- a/travis-install-magento.sh
+++ b/travis-install-magento.sh
@@ -106,6 +106,9 @@ function install_magento() {
       php bin/magento setup:upgrade
     fi
 
+
+    cp $DIR_BASE/install-config-mysql*.dist dev/tests/integration/etc
+
     mv ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini.bak ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     cd -
 }

--- a/travis-install-magento.sh
+++ b/travis-install-magento.sh
@@ -28,7 +28,7 @@ BASE_URL="https://$BASE_DOMAIN"
 
 function prepare_php_and_apache() {
     if [ "$FULL_INSTALL" -eq "0" ]; then
-      echo "The instance is not configured without a full install"
+      echo "Not configuring php-fpm and apachec as this is not a full install"
       return 0;
     fi
 
@@ -132,7 +132,7 @@ function with_sampledata() {
 
 function assert_alive() {
     if [ "$FULL_INSTALL" -eq "0" ]; then
-      echo "The instance is not configured without a full install"
+      echo "Not performing any database checks as this is not a full instance"
       return 0;
     fi
 
@@ -142,6 +142,17 @@ function assert_alive() {
     mysql -hlocalhost -uroot $DATABASE_NAME -e "select count(*) from catalog_product_entity;"
 }
 
+function install_elasticsearch() {
+  sudo apt-get remove elasticsearch -y
+  curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb
+  sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb
+  sudo chown elasticsearch:elasticsearch /etc/default/elasticsearch
+  sudo service elasticsearch restart
+  sleep 5
+  curl -XGET 'localhost:9200' | grep "You Know, for Search"
+}
+
+install_elasticsearch
 install_magento
 prepare_php_and_apache
 assert_alive


### PR DESCRIPTION
This allows us to install the minimal magento required for integration tests to be run against.