### PR TITLE
Fix elasticsearch installation

### DIFF
--- a/travis-install-magento.sh
+++ b/travis-install-magento.sh
@@ -149,13 +149,17 @@ function assert_alive() {
 }
 
 function install_elasticsearch() {
+  curl -XGET 'localhost:9200'
+  curl -XGET 'localhost:9200/_cat/indices?v'
   sudo apt-get remove elasticsearch -y
+  sudo rm -rf /etc/elasticsearch /etc/default/elasticsearch /var/lib/elasticsearch/
   curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb
   sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb
   sudo chown elasticsearch:elasticsearch /etc/default/elasticsearch
-  sudo service elasticsearch restart
+  sudo service elasticsearch restart || sudo journalctl -xe
   sleep 5
-  curl -XGET 'localhost:9200' | grep "You Know, for Search"
+  curl -XGET 'localhost:9200'
+  curl -XGET 'localhost:9200/_cat/indices?v'
 }
 
 install_elasticsearch

--- a/travis-install-magento.sh
+++ b/travis-install-magento.sh
@@ -149,8 +149,6 @@ function assert_alive() {
 }
 
 function install_elasticsearch() {
-  curl -XGET 'localhost:9200'
-  curl -XGET 'localhost:9200/_cat/indices?v'
   sudo apt-get remove elasticsearch -y
   sudo rm -rf /etc/elasticsearch /etc/default/elasticsearch /var/lib/elasticsearch/
   curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb


### PR DESCRIPTION
Newer default version of elasticsearch has a geoip database indice by default
https://discuss.elastic.co/t/how-to-disable-geoip-usage-in-7-14-0/281076

This means that the default indices on the file system have syntax relative to the newer version of ES so when we downgrade to a Magento compatible version it all goes wrong and fails to boot with an error like
```
Caused by: org.apache.lucene.index.IndexFormatTooNewException: Format version is not supported
```

This PR adds some future useful debugging information as well as fixes the error