### PR TITLE
Disable `magento/composer-dependency-version-audit-plugin`

### DIFF
--- a/replace-dependencies.php
+++ b/replace-dependencies.php
@@ -1,0 +1,28 @@
+<?php
+set_error_handler(function ($severity, $message, $file, $line) {
+    throw new \ErrorException($message, $severity, $severity, $file, $line);
+});
+
+$directory = $argv[1];
+echo "replace-dependencies.php - START - modify composer.json in $directory" . PHP_EOL;
+
+$dependenciesToReplace = [
+    'magento/composer-dependency-version-audit-plugin'
+];
+
+$contents = \json_decode(file_get_contents($directory . '/composer.json'), true);
+
+if (!isset($contents['replace'])) {
+    $contents['replace'] = [];
+}
+
+foreach ($dependenciesToReplace as $dep) {
+    $contents['replace'][$dep] = '*';
+}
+
+$newContents = \json_encode($contents, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+file_put_contents($directory . '/composer.json', $newContents);
+
+echo $newContents;
+
+echo "replace-dependencies.php - DONE" . PHP_EOL;

--- a/travis-install-magento.sh
+++ b/travis-install-magento.sh
@@ -78,6 +78,7 @@ function install_magento() {
     mysql -hlocalhost -uroot -e "create database if not exists $DATABASE_NAME"
 
     printf "\033[92m###### Composer creating $BASE_URL project at $DIR_TARGET ######\n\n\033[0m";
+    set -v
     composer create-project --repository=$COMPOSER_REPOSITORY magento/project-community-edition=$VERSION $DIR_TARGET --no-install --no-plugins
     cd $DIR_TARGET
     composer config --no-interaction allow-plugins.dealerdirect/phpcodesniffer-composer-installer true || true
@@ -88,7 +89,8 @@ function install_magento() {
     composer config repo.composerrepository composer $COMPOSER_REPOSITORY
     composer config minimum-stability dev
     composer config prefer-stable true
-
+    cat composer.json
+    
     # Use lower version of monolog, https://github.com/magento/magento2/pull/35596 
     # If composer install fails its likely because of that in 2.4.5 it requires >=2.7.0
     composer require monolog/monolog:"<2.7.0" --no-update

--- a/travis-install-magento.sh
+++ b/travis-install-magento.sh
@@ -78,25 +78,22 @@ function install_magento() {
     mysql -hlocalhost -uroot -e "create database if not exists $DATABASE_NAME"
 
     printf "\033[92m###### Composer creating $BASE_URL project at $DIR_TARGET ######\n\n\033[0m";
-    set -v
     composer create-project --repository=$COMPOSER_REPOSITORY magento/project-community-edition=$VERSION $DIR_TARGET --no-install --no-plugins
     cd $DIR_TARGET
-    composer config --no-interaction --unset allow-plugins.magento/* || true
     composer config --no-interaction allow-plugins.dealerdirect/phpcodesniffer-composer-installer true || true
     composer config --no-interaction allow-plugins.laminas/laminas-dependency-plugin true || true
-    composer config --no-interaction allow-plugins.magento/composer-dependency-version-audit-plugin false
-    composer config --no-interaction allow-plugins.magento/foobar true || true
+    composer config --no-interaction allow-plugins.magento/* true || true
     composer config --unset repo.0
     composer config repo.composerrepository composer $COMPOSER_REPOSITORY
     composer config minimum-stability dev
     composer config prefer-stable true
 
+    # CLI management of composer replace dependencies
+    php $DIR_BASE/replace-dependencies.php $DIR_TARGET
+
     # Use lower version of monolog, https://github.com/magento/magento2/pull/35596 
     # If composer install fails its likely because of that in 2.4.5 it requires >=2.7.0
     composer require monolog/monolog:"<2.7.0" --no-update
-    composer remove magento/composer-dependency-version-audit-plugin --no-update || true
-    cat composer.json
-    ls -l composer.*
     composer install || (composer remove monolog/monolog --no-update --no-interaction && composer install)
 
     php bin/magento | head -2

--- a/travis-install-magento.sh
+++ b/travis-install-magento.sh
@@ -170,7 +170,7 @@ function install_elasticsearch() {
   curl -XGET 'localhost:9200/_cat/indices?v'
 }
 
-#install_elasticsearch
+install_elasticsearch
 install_magento
 prepare_php_and_apache
 assert_alive

--- a/travis-install-magento.sh
+++ b/travis-install-magento.sh
@@ -81,6 +81,7 @@ function install_magento() {
     set -v
     composer create-project --repository=$COMPOSER_REPOSITORY magento/project-community-edition=$VERSION $DIR_TARGET --no-install --no-plugins
     cd $DIR_TARGET
+    composer config --no-interaction --unset allow-plugins.magento/* || true
     composer config --no-interaction allow-plugins.dealerdirect/phpcodesniffer-composer-installer true || true
     composer config --no-interaction allow-plugins.laminas/laminas-dependency-plugin true || true
     composer config --no-interaction allow-plugins.magento/composer-dependency-version-audit-plugin false
@@ -89,12 +90,13 @@ function install_magento() {
     composer config repo.composerrepository composer $COMPOSER_REPOSITORY
     composer config minimum-stability dev
     composer config prefer-stable true
-    cat composer.json
-    
+
     # Use lower version of monolog, https://github.com/magento/magento2/pull/35596 
     # If composer install fails its likely because of that in 2.4.5 it requires >=2.7.0
     composer require monolog/monolog:"<2.7.0" --no-update
     composer remove magento/composer-dependency-version-audit-plugin --no-update || true
+    cat composer.json
+    ls -l composer.*
     composer install || (composer remove monolog/monolog --no-update --no-interaction && composer install)
 
     php bin/magento | head -2
@@ -171,7 +173,7 @@ function install_elasticsearch() {
   curl -XGET 'localhost:9200/_cat/indices?v'
 }
 
-install_elasticsearch
+#install_elasticsearch
 install_magento
 prepare_php_and_apache
 assert_alive

--- a/travis-install-magento.sh
+++ b/travis-install-magento.sh
@@ -82,7 +82,8 @@ function install_magento() {
     cd $DIR_TARGET
     composer config --no-interaction allow-plugins.dealerdirect/phpcodesniffer-composer-installer true || true
     composer config --no-interaction allow-plugins.laminas/laminas-dependency-plugin true || true
-    composer config --no-interaction allow-plugins.magento/* true || true
+    composer config --no-interaction allow-plugins.magento/composer-dependency-version-audit-plugin false
+    composer config --no-interaction allow-plugins.magento/foobar true || true
     composer config --unset repo.0
     composer config repo.composerrepository composer $COMPOSER_REPOSITORY
     composer config minimum-stability dev


### PR DESCRIPTION
Disable the dependency manager plugin. When a new public magento module is tagged and the fooman mirror lags behind a bit, then we get this issue.

It's not very useful anyway https://github.com/magento/composer-dependency-version-audit-plugin/issues/6

```
In Plugin.php line 160:
                                                                               
  Higher matching version 4.0.1 of magento/magento2-functional-testing-framew  
  ork was found in public repository packagist.org                             
                               than 4.0.0 in private https://repo-magento-mir  
  ror.fooman.co.nz. Public package might've been taken over by a malicious en  
  tity,                                                                        
                               please investigate and update package requirem  
  ent to match the version from the private repository                                                                                                
```